### PR TITLE
Link to GitHub from DESCRIPTION

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -33,6 +33,8 @@ Description: Provides an R wrapper for the 'MD4C' (Markdown for 'C') library.
     abstract syntax trees as well as translating and displaying the documents.
 License: MIT + file LICENSE
 Copyright: John MacFarlane, RStudio, PBC; Martin Mitáš, Colin Rundel
+URL: https://rundel.github.io/md4r/, https://github.com/rundel/md4r
+BugReports: https://github.com/rundel/md4r/issues
 Encoding: UTF-8
 LazyData: true
 Roxygen: list(markdown = TRUE)


### PR DESCRIPTION
So that the source of the package is easier to discover, and to enable downlit autolinking.